### PR TITLE
fix: sync session IDs to tmux env on load for resume functionality

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1735,8 +1735,16 @@ func (i *Instance) Kill() error {
 // For Claude sessions with known ID: sends Ctrl+C twice and resume command to existing session
 // For dead sessions or unknown ID: recreates the tmux session
 func (i *Instance) Restart() error {
-	log.Printf("[MCP-DEBUG] Instance.Restart() called - Tool=%s, ClaudeSessionID=%q, tmuxSession=%v, tmuxExists=%v",
-		i.Tool, i.ClaudeSessionID, i.tmuxSession != nil, i.tmuxSession != nil && i.tmuxSession.Exists())
+	log.Printf("[MCP-DEBUG] Instance.Restart() called - Tool=%s, ClaudeSessionID=%q, GeminiSessionID=%q, tmuxSession=%v, tmuxExists=%v",
+		i.Tool, i.ClaudeSessionID, i.GeminiSessionID, i.tmuxSession != nil, i.tmuxSession != nil && i.tmuxSession.Exists())
+
+	// For Gemini: Update session ID from filesystem BEFORE attempting restart
+	// This ensures we have the latest session ID even if agent-deck was restarted
+	if i.Tool == "gemini" {
+		log.Printf("[RESTART-DEBUG] Gemini: calling UpdateGeminiSession() to detect session ID")
+		i.UpdateGeminiSession(nil)
+		log.Printf("[RESTART-DEBUG] Gemini: after UpdateGeminiSession, GeminiSessionID=%q", i.GeminiSessionID)
+	}
 
 	// Clear flag immediately to prevent it staying set if restart fails
 	skipRegen := i.SkipMCPRegenerate

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -548,6 +548,18 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 		// Without this, UI renders saved status, then first tick changes it
 		if tmuxSess != nil {
 			_ = inst.UpdateStatus()
+
+			// Sync ClaudeSessionID to tmux environment for resume functionality
+			// This ensures R key works after agent-deck restart
+			// The tmux env var may be lost when agent-deck closes, but sessions.json preserves it
+			if inst.ClaudeSessionID != "" && tmuxSess.Exists() {
+				_ = tmuxSess.SetEnvironment("CLAUDE_SESSION_ID", inst.ClaudeSessionID)
+			}
+
+			// Sync GeminiSessionID to tmux environment for resume functionality
+			if inst.GeminiSessionID != "" && tmuxSess.Exists() {
+				_ = tmuxSess.SetEnvironment("GEMINI_SESSION_ID", inst.GeminiSessionID)
+			}
 		}
 
 		instances[i] = inst


### PR DESCRIPTION
## Summary

- Fixes the issue where pressing R (resume) after restarting agent-deck would not properly resume Claude/Gemini sessions
- When agent-deck restarts, tmux environment variables are lost but sessions.json preserves the session IDs
- This PR syncs the stored session IDs back to tmux environment on load

## Problem

1. User starts Claude session in agent-deck
2. Session ID is captured and stored in `sessions.json` 
3. User closes agent-deck
4. User reopens agent-deck
5. `GetSessionIDFromTmux()` returns empty because tmux env var is lost
6. R key fails to resume session

## Solution

After loading sessions from JSON and reconnecting to tmux sessions, sync the stored `ClaudeSessionID` and `GeminiSessionID` back to tmux environment variables.

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [ ] Manual test: Start Claude session, close agent-deck, reopen, press R to resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better synchronization of per-instance session IDs into the tmux environment so sessions remain linked after updates.
  * Cross-project session discovery and fallback reading so sessions created in different working directories are found.
  * Improved logging around session discovery and restart paths to aid troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->